### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# octofacts
+
+language: ruby
+install: true
+script: "script/cibuild"
+
+matrix:
+  include:
+    - rvm: 2.4
+    - rvm: 2.3.2
+    - rvm: 2.2.3
+    - rvm: 2.1

--- a/lib/octofacts/facts.rb
+++ b/lib/octofacts/facts.rb
@@ -81,7 +81,7 @@ module Octofacts
         return self
       end
 
-      if facts.respond_to?(name)
+      if facts.respond_to?(name, false)
         if args[0].is_a?(String) || args[0].is_a?(Symbol)
           args[0] = string_or_symbolized_key(args[0])
         end
@@ -91,11 +91,11 @@ module Octofacts
       raise NameError, "Unknown method '#{name}' in #{self.class}"
     end
 
-    def respond_to?(method)
+    def respond_to?(method, include_all = false)
       camelized_name = (method.to_s).split("_").collect(&:capitalize).join
       super || Kernel.const_get("Octofacts::Manipulators::#{camelized_name}")
     rescue NameError
-      return facts.respond_to?(method)
+      return facts.respond_to?(method, include_all)
     end
 
     private

--- a/spec/octofacts_updater/fixture_spec.rb
+++ b/spec/octofacts_updater/fixture_spec.rb
@@ -177,7 +177,15 @@ describe OctofactsUpdater::Fixture do
       obj.write_file(outfile)
 
       expect(File.file?(outfile)).to eq(true)
-      expect(File.read(outfile)).to eq(File.read(fixture_file))
+
+      # Different ruby versions or environments can cause the YAML generation to be slightly different.
+      # For example we ran into this diff:
+      #   -    uuid: 09809809-0980-0980-0980-098098098098
+      #   +    uuid: '09809809-0980-0980-0980-098098098098'
+      # To avoid this parse the YAML and compare that instead.
+      fixture_yaml = YAML.safe_load(File.read(fixture_file))
+      generated_yaml = YAML.safe_load(File.read(outfile))
+      expect(generated_yaml).to eq(fixture_yaml)
     end
   end
 end


### PR DESCRIPTION
Set up Travis CI.

Fixes two problems exposed by the Travis environment:

- Update `respond_to?` method to the currently supported 2-argument version
- Update one test where ruby version caused slightly different YAML, to compare parsed YAML instead of text